### PR TITLE
feat: add drop target

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ and installers easier on macOS. Just drag and drop!
 2. CMake 3.21+
 
 ### Build
-1. `git@github.com:dwosk/codesign-verifier-app.git`
+1. `git clone git@github.com:dwosk/codesign-verifier-app.git`
 2. `cd codesign-verifier-app`
 3. `./cbuild`

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(codesign-verifier-app PRIVATE
 set_target_properties(codesign-verifier-app PROPERTIES
     OUTPUT_NAME                                         "${PRETTY_APP_NAME}"
     XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME  AppIcon
+    XCODE_ATTRIBUTE_ENABLE_TESTABILITY                  YES
     XCODE_ATTRIBUTE_SWIFT_OPTIMIZATION_LEVEL            "$<IF:$<CONFIG:Debug>,-Onone,-O>")
 
 set(RESOURCE_FILES

--- a/src/Views/ContentView.swift
+++ b/src/Views/ContentView.swift
@@ -9,14 +9,41 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        TextView()
-            .frame(width: 400, height: 600)
+        ZStack {
+            DropTargetView()
+        }
+        .frame(width: 400, height: 600)
+        .onDrop(of: ["public.file-url"], delegate: FileDropDelegate())
     }
 }
 
-struct TextView: View {
+struct FileDropDelegate: DropDelegate {
+    func performDrop(info: DropInfo) -> Bool {
+        print("Handling drop event")
+        guard info.hasItemsConforming(to: ["public.file-url"]) else {
+            return false
+        }
+
+        if let item = info.itemProviders(for: ["public.file-url"]).first {
+            item.loadItem(forTypeIdentifier: "public.file-url", options: nil) { (urlData, error) in
+                DispatchQueue.main.async {
+                    if let urlData = urlData as? Data {
+                        let fileUrl = NSURL(absoluteURLWithDataRepresentation: urlData, relativeTo: nil) as URL
+                        print(fileUrl.absoluteURL)
+                    }
+                }
+            }
+
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+struct DropTargetView: View {
     var body: some View {
-        Text("Hello, world!")
+        Text("Drop Files here!")
             .font(.largeTitle)
             .padding()
     }
@@ -27,6 +54,6 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
             .preferredColorScheme(.light)
         ContentView()
-            .preferredColorScheme(.dark)
+            .preferredColorScheme(.light)
     }
 }

--- a/src/Views/ContentView.swift
+++ b/src/Views/ContentView.swift
@@ -13,7 +13,6 @@ struct ContentView: View {
             DropTargetView()
         }
         .frame(width: 400, height: 600)
-        .onDrop(of: ["public.file-url"], delegate: FileDropDelegate())
     }
 }
 
@@ -43,9 +42,22 @@ struct FileDropDelegate: DropDelegate {
 
 struct DropTargetView: View {
     var body: some View {
-        Text("Drop Files here!")
-            .font(.largeTitle)
-            .padding()
+        ZStack {
+            let radius: CGFloat = 20
+            let backgroundRectangle = RoundedRectangle(cornerRadius: radius).foregroundColor(Color.gray)
+                .opacity(0.6)
+            RoundedRectangle(cornerRadius: radius)
+                .strokeBorder(Color.gray, lineWidth: 4)
+                .background(backgroundRectangle)
+
+            VStack {
+                Text("Drop File here!")
+                    .font(.largeTitle)
+                    .padding()
+            }
+        }
+        .padding(.all, 20.0)
+        .onDrop(of: ["public.file-url"], delegate: FileDropDelegate())
     }
 }
 

--- a/src/Views/ContentView.swift
+++ b/src/Views/ContentView.swift
@@ -19,12 +19,13 @@ struct ContentView: View {
 struct FileDropDelegate: DropDelegate {
     func performDrop(info: DropInfo) -> Bool {
         print("Handling drop event")
-        guard info.hasItemsConforming(to: ["public.file-url"]) else {
+        let supportedTypes = ["public.file-url"]
+        guard info.hasItemsConforming(to: supportedTypes) else {
             return false
         }
 
-        if let item = info.itemProviders(for: ["public.file-url"]).first {
-            item.loadItem(forTypeIdentifier: "public.file-url", options: nil) { (urlData, error) in
+        if let item = info.itemProviders(for: supportedTypes).first {
+            item.loadItem(forTypeIdentifier: supportedTypes[0], options: nil) { (urlData, error) in
                 DispatchQueue.main.async {
                     if let urlData = urlData as? Data {
                         let fileUrl = NSURL(absoluteURLWithDataRepresentation: urlData, relativeTo: nil) as URL
@@ -44,7 +45,8 @@ struct DropTargetView: View {
     var body: some View {
         ZStack {
             let radius: CGFloat = 20
-            let backgroundRectangle = RoundedRectangle(cornerRadius: radius).foregroundColor(Color.gray)
+            let backgroundRectangle = RoundedRectangle(cornerRadius: radius)
+                .foregroundColor(Color.gray)
                 .opacity(0.6)
             RoundedRectangle(cornerRadius: radius)
                 .strokeBorder(Color.gray, lineWidth: 4)

--- a/src/Views/ContentView.swift
+++ b/src/Views/ContentView.swift
@@ -68,6 +68,6 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
             .preferredColorScheme(.light)
         ContentView()
-            .preferredColorScheme(.light)
+            .preferredColorScheme(.dark)
     }
 }


### PR DESCRIPTION
Creates a simple styled view with `onDrop` attribute that handles dropped files and prints the file path to the console.